### PR TITLE
Use package-relative imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Here’s a simple example of how to train and use the Naive Bayes classifier.
 First, define a `featurizer` function to convert your raw data into a list of `Feature` objects. Each feature specifies its name, distribution, and value.
 
 ```python
-import nb
-import distributions
+from src import nb, distributions
 
 def featurizer(data_point: list[str]) -> list[nb.Feature]:
     return [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ dev = ["ruff", "pyright", "pytest", "pytest-cov", "coverage[toml]", "pre-commit"
 pythonVersion = "3.12"
 typeCheckingMode = "basic"
 extraPaths = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/src/distributions.py
+++ b/src/distributions.py
@@ -12,12 +12,16 @@ class Distribution(object):
         raise NotImplementedError("Subclasses should override.")
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "Distribution":
+    def mle_estimate(cls, points: Iterable[float]) -> "Distribution":
         raise NotImplementedError("Subclasses should override.")
 
     @classmethod
-    def momEstimate(cls, points: Iterable[float]) -> "Distribution":
+    def mom_estimate(cls, points: Iterable[float]) -> "Distribution":
         raise NotImplementedError("Subclasses should override.")
+
+    # Backwards compatibility with camelCase names
+    mleEstimate = mle_estimate
+    momEstimate = mom_estimate
 
 
 ## ContinuousDistribution ##############################################################################
@@ -63,8 +67,10 @@ class Uniform(ContinuousDistribution):
         )
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "Uniform":
+    def mle_estimate(cls, points: Iterable[float]) -> "Uniform":
         return cls(min(points), max(points))
+
+    mleEstimate = mle_estimate
 
 
 ## Gaussian ############################################################################################
@@ -99,7 +105,7 @@ class Gaussian(ContinuousDistribution):
         )
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "Gaussian":
+    def mle_estimate(cls, points: Iterable[float]) -> "Gaussian":
         points_list = list(points)
         numPoints = float(len(points_list))
         if numPoints <= 1:
@@ -114,6 +120,8 @@ class Gaussian(ContinuousDistribution):
         stdev = math.sqrt(variance)
 
         return cls(mean, stdev)
+
+    mleEstimate = mle_estimate
 
 
 ## TruncatedGaussian ##################################################################################
@@ -163,7 +171,7 @@ class TruncatedGaussian(ContinuousDistribution):
         )
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "TruncatedGaussian":
+    def mle_estimate(cls, points: Iterable[float]) -> "TruncatedGaussian":
         points_list = list(points)
         numPoints = float(len(points_list))
 
@@ -179,6 +187,8 @@ class TruncatedGaussian(ContinuousDistribution):
         stdev = math.sqrt(variance)
 
         return cls(mean, stdev, min(points_list), max(points_list))
+
+    mleEstimate = mle_estimate
 
     def __phi(self, value: float) -> float:
         return 0.5 * (
@@ -219,7 +229,7 @@ class LogNormal(ContinuousDistribution):
         )
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "LogNormal":
+    def mle_estimate(cls, points: Iterable[float]) -> "LogNormal":
         points_list = list(points)
         numPoints = float(len(points_list))
 
@@ -235,6 +245,8 @@ class LogNormal(ContinuousDistribution):
         stdev = math.sqrt(variance)
 
         return cls(mean, stdev)
+
+    mleEstimate = mle_estimate
 
 
 ## Exponential ########################################################################################
@@ -261,7 +273,7 @@ class Exponential(ContinuousDistribution):
         return "Continuous Exponential distribution: lamda = %s" % self.lambdaa
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "Exponential":
+    def mle_estimate(cls, points: Iterable[float]) -> "Exponential":
         points_list = list(points)
         if len(points_list) == 0:
             raise EstimationError("Must provide at least one point.")
@@ -276,6 +288,8 @@ class Exponential(ContinuousDistribution):
             raise ParametrizationError("Mean of points must be positive.")
 
         return cls(1.0 / mean)
+
+    mleEstimate = mle_estimate
 
 
 ## KernelDensityEstimate ##############################################################################
@@ -317,8 +331,10 @@ class KernelDensityEstimate(ContinuousDistribution):
         return "Continuous Gaussian Kernel Density Estimate distribution"
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "KernelDensityEstimate":
+    def mle_estimate(cls, points: Iterable[float]) -> "KernelDensityEstimate":
         return cls(points)
+
+    mleEstimate = mle_estimate
 
 
 ## DiscreteDistribution ###############################################################################
@@ -353,8 +369,10 @@ class DiscreteUniform(DiscreteDistribution):
         )
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[float]) -> "DiscreteUniform":
+    def mle_estimate(cls, points: Iterable[float]) -> "DiscreteUniform":
         return cls(min(points), max(points))
+
+    mleEstimate = mle_estimate
 
 
 ## Poisson ############################################################################################
@@ -378,10 +396,12 @@ class Poisson(DiscreteDistribution):
         return "Discrete Poisson distribution: lamda = %s" % self.lambdaa
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[int]) -> "Poisson":
+    def mle_estimate(cls, points: Iterable[int]) -> "Poisson":
         points_list = list(points)
         mean = float(sum(points_list)) / float(len(points_list))
         return cls(mean)
+
+    mleEstimate = mle_estimate
 
 
 ## Multinomial #######################################################################################
@@ -407,11 +427,13 @@ class Multinomial(DiscreteDistribution):
         return "Discrete Multinomial distribution: buckets = %s" % self.categoryCounts
 
     @classmethod
-    def mleEstimate(cls, points: Iterable[Any]) -> "Multinomial":
+    def mle_estimate(cls, points: Iterable[Any]) -> "Multinomial":
         categoryCounts: Dict[Any, int] = collections.Counter()
         for point in points:
             categoryCounts[point] += 1
         return cls(categoryCounts)
+
+    mleEstimate = mle_estimate
 
 
 ## Binary ############################################################################################
@@ -431,7 +453,7 @@ class Binary(Multinomial):
         )
 
     @classmethod
-    def mleEstimate(
+    def mle_estimate(
         cls, points: Iterable[bool], smoothingFactor: float = 1.0
     ) -> "Binary":
         points_list = list(points)
@@ -441,6 +463,8 @@ class Binary(Multinomial):
                 trueCount += 1
         falseCount = len(points_list) - trueCount
         return cls(trueCount, falseCount, smoothingFactor)
+
+    mleEstimate = mle_estimate
 
 
 ## Errors ############################################################################################

--- a/src/nb.py
+++ b/src/nb.py
@@ -4,25 +4,20 @@ import sys
 import collections
 import math
 import operator
-import copy
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type
 
-import distributions
+from . import distributions
 
 
 ## Feature ##############################################################################
 
 
-class Feature(object):
-    def __init__(
-        self, name: str, distribution: Type[distributions.Distribution], value: Any
-    ) -> None:
-        self.name: str = name
-        self.distribution: Type[distributions.Distribution] = distribution
-        self.value: Any = value
-
-    def __repr__(self) -> str:
-        return self.name + " => " + str(self.value)
+@dataclass
+class Feature:
+    name: str
+    distribution: Type[distributions.Distribution]
+    value: Any
 
     def hashable(self) -> tuple[str, Any]:
         return (self.name, self.value)
@@ -100,7 +95,7 @@ class NaiveBayesClassifier(object):
                             trueCount, falseCount
                         )
                     else:
-                        distribution = distributionTypes[featureName].mleEstimate(
+                        distribution = distributionTypes[featureName].mle_estimate(
                             values
                         )
                 except (
@@ -135,7 +130,7 @@ class NaiveBayesClassifier(object):
             raise Exception("Classifier has not been trained")
         features = self.featurize(object)
 
-        labelWeights: Dict[Any, float] = copy.deepcopy(self.priors)
+        labelWeights: Dict[Any, float] = self.priors.copy()
 
         for feature in features:
             for label in self.priors:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,36 +1,32 @@
-import sys
-from pathlib import Path
-
-# Ensure src directory is on sys.path for imports
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import math
 
 import pytest
-import distributions
-import math
+
+from src import distributions
 
 
 def test_exponential_mle_estimate_errors():
     # No data points should raise an estimation error
     with pytest.raises(distributions.EstimationError):
-        distributions.Exponential.mleEstimate([])
+        distributions.Exponential.mle_estimate([])
 
     # Negative data points are not allowed for exponential distribution
     with pytest.raises(distributions.EstimationError):
-        distributions.Exponential.mleEstimate([-1.0, 2.0])
+        distributions.Exponential.mle_estimate([-1.0, 2.0])
 
     # Mean of zero leads to a parametrization error
     with pytest.raises(distributions.ParametrizationError):
-        distributions.Exponential.mleEstimate([0.0, 0.0])
+        distributions.Exponential.mle_estimate([0.0, 0.0])
 
 
 def test_gaussian_mle_estimate():
-    dist = distributions.Gaussian.mleEstimate([1.0, 2.0, 3.0, 4.0])
+    dist = distributions.Gaussian.mle_estimate([1.0, 2.0, 3.0, 4.0])
     assert dist.mean == pytest.approx(2.5)
     assert dist.stdev == pytest.approx(math.sqrt(5.0 / 3.0))
 
 
 def test_poisson_mle_estimate():
-    dist = distributions.Poisson.mleEstimate([2, 3, 4])
+    dist = distributions.Poisson.mle_estimate([2, 3, 4])
     assert dist.lambdaa == pytest.approx(3.0)
     expected = (3.0**3) / math.factorial(3) * math.exp(-3.0)
     assert dist.probability(3) == pytest.approx(expected)
@@ -46,7 +42,7 @@ def test_continuous_distributions() -> None:
     assert gaussian.pdf(0.0) > 0
     assert math.isclose(gaussian.cdf(0.0), 0.5)
 
-    tg = distributions.TruncatedGaussian.mleEstimate([0.0, 1.0, 0.5])
+    tg = distributions.TruncatedGaussian.mle_estimate([0.0, 1.0, 0.5])
     assert tg.pdf(0.5) > 0
 
     ln = distributions.LogNormal(0.0, 1.0)
@@ -72,5 +68,5 @@ def test_discrete_distributions() -> None:
     m = distributions.Multinomial({"a": 2, "b": 1})
     assert m.probability("a") > m.probability("c")
 
-    bin_est = distributions.Binary.mleEstimate([True, False, True])
+    bin_est = distributions.Binary.mle_estimate([True, False, True])
     assert isinstance(bin_est, distributions.Binary)

--- a/tests/test_nb.py
+++ b/tests/test_nb.py
@@ -1,12 +1,6 @@
-import sys
-from pathlib import Path
-
-# Ensure src directory is on sys.path for imports
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
-import nb
-import distributions
 import pytest
+
+from src import distributions, nb
 
 
 def test_classify_and_accuracy():


### PR DESCRIPTION
## Summary
- switch Naive Bayes module to use package-relative imports
- remove test sys.path hacks and configure pytest to discover the package
- refresh README example for new import style
- convert Feature to a dataclass for cleaner attribute handling
- avoid unnecessary deep copy when computing label weights
- rename estimation helpers to snake_case for PEP 8 compliance

## Testing
- `uv run pre-commit run --files src/distributions.py src/nb.py tests/test_distributions.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948bd4a72083268bc6fe9e8e677b56